### PR TITLE
Fix '-Werror=shift-negative-value' for gcc 6

### DIFF
--- a/libfixmath/fix16.h
+++ b/libfixmath/fix16.h
@@ -307,7 +307,7 @@ extern fix16_t fix16_from_str(const char *buf);
     ( \
       (( #i[0] ) == '-') \
         ? -FIXMATH_COMBINE_I_M((unsigned)( ( (i) * -1) ), m) \
-        : FIXMATH_COMBINE_I_M(i, m) \
+        : FIXMATH_COMBINE_I_M((unsigned)i, m) \
     ) \
 )
 


### PR DESCRIPTION
GCC 6 introduced warning for shift on negative value numbers.
When F16C is called with a negative number it evaluates `FIXMATH_COMBINE_I_M` with both the positive and the negative value.

Fixes #3 

The other solution I see, is to introduce a `_SIGN` macro that does this check with `'-'` and do

```
_SIGN(i) * FIXMATH_COMBINE_I_M( (unsigned) (_SIGN(i) * i), m)
```