### PR TITLE
Update pio manifest to satisfy registry add rules

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,7 +1,11 @@
 {
   "name": "libfixmath",
   "description": "Cross Platform Fixed Point Maths Library",
-  "version": "0.0.0",
+  "keywords": [
+    "fixed",
+    "point",
+    "math"
+  ],
   "repository": {
       "type": "git",
       "url": "https://github.com/PetteriAimonen/libfixmath.git"


### PR DESCRIPTION
Previous commit was tested via "direct github repo link". But when i tried add your project into pio pkg registry (to use dependency by plain name), it rejected with minor error:

```
Invalid library config: The 'name, keywords and description' fields are required
```

 This PR should fix that (sorry, can't test such thing from fork). Also removed `version` field - not required when repo link set.