### PR TITLE
platformio: drop 'export' option from config

### DIFF
--- a/library.json
+++ b/library.json
@@ -11,9 +11,6 @@
       "url": "https://github.com/PetteriAimonen/libfixmath.git"
   },
   "license": "MIT",
-  "export": {
-    "include": "libfixmath"
-  },
   "build": {
     "srcFilter": "+<libfixmath/*>"
   },


### PR DESCRIPTION
Library should be useable from pio both by direct git link and by name.

Hope this is the last change (library is already in PIO registly https://platformio.org/lib/show/5575/libfixmath/installation)