### PR TITLE
Fix missing function when building without overflow support

### DIFF
--- a/libfixmath/fix16_trig.c
+++ b/libfixmath/fix16_trig.c
@@ -113,7 +113,11 @@ fix16_t fix16_cos(fix16_t inAngle)
 
 fix16_t fix16_tan(fix16_t inAngle)
 {
+	#ifndef FIXMATH_NO_OVERFLOW
 	return fix16_sdiv(fix16_sin(inAngle), fix16_cos(inAngle));
+	#elif
+	return fix16_div(fix16_sin(inAngle), fix16_cos(inAngle));
+	#endif
 }
 
 fix16_t fix16_asin(fix16_t x)


### PR DESCRIPTION
Hi there!

Currently building with `-DFIXMATH_NO_OVERFLOW` gives you the following warning:
```c
gcc -O2  -Wall -Wextra -c -DFIXMATH_NO_OVERFLOW -o fix16_trig.o fix16_trig.c

fix16_trig.c: In function ‘fix16_tan’:
fix16_trig.c:116:9: warning: implicit declaration of function ‘fix16_sdiv’; did you mean ‘fix16_div’? [-Wimplicit-function-declaration]
  116 |  return fix16_sdiv(fix16_sin(inAngle), fix16_cos(inAngle));
      |         ^~~~~~~~~~
      |         fix16_div
```

I simply added preprocessor macros to use `fix16_div` instead of `fix16_sdiv` when compiling without overflow detection support.