### PR TITLE
add #include <stdint.h> to int64.h

### DIFF
--- a/libfixmath/int64.h
+++ b/libfixmath/int64.h
@@ -6,6 +6,8 @@ extern "C"
 {
 #endif
 
+#include <stdint.h>
+
 #ifndef FIXMATH_NO_64BIT
 static inline  int64_t int64_const(int32_t hi, uint32_t lo) { return (((int64_t)hi << 32) | lo); }
 static inline  int64_t int64_from_int32(int32_t x) { return (int64_t)x; }


### PR DESCRIPTION
When using the `gcc -M` option to determine header file dependencies, int64.h causes an error because the types from stdint.h are not defined.