### PR TITLE
Fix GCC error when compiling in no-overflow mode

### DIFF
--- a/libfixmath/fix16_trig.c
+++ b/libfixmath/fix16_trig.c
@@ -115,7 +115,7 @@ fix16_t fix16_tan(fix16_t inAngle)
 {
 	#ifndef FIXMATH_NO_OVERFLOW
 	return fix16_sdiv(fix16_sin(inAngle), fix16_cos(inAngle));
-	#elif
+	#else
 	return fix16_div(fix16_sin(inAngle), fix16_cos(inAngle));
 	#endif
 }


### PR DESCRIPTION
Hi! 

`fix16_trig.c` contained an `elif` without any condition, which caused the preprocessor to crash. This error only seem to happen when compiling with `-DFIXMATH_NO_OVERFLOW`.