### PR TITLE
Fix type conversion bugs in linear interpolation functions

### DIFF
--- a/libfixmath/fix16.c
+++ b/libfixmath/fix16.c
@@ -485,7 +485,7 @@ fix16_t fix16_mod(fix16_t x, fix16_t y)
 
 fix16_t fix16_lerp8(fix16_t inArg0, fix16_t inArg1, uint8_t inFract)
 {
-	int64_t tempOut = int64_mul_i32_i32(inArg0, ((1 << 8) - inFract));
+	int64_t tempOut = int64_mul_i32_i32(inArg0, (((int32_t)1 << 8) - inFract));
 	tempOut = int64_add(tempOut, int64_mul_i32_i32(inArg1, inFract));
 	tempOut = int64_shift(tempOut, -8);
 	return (fix16_t)int64_lo(tempOut);
@@ -502,7 +502,7 @@ fix16_t fix16_lerp16(fix16_t inArg0, fix16_t inArg1, uint16_t inFract)
 fix16_t fix16_lerp32(fix16_t inArg0, fix16_t inArg1, uint32_t inFract)
 {
 	int64_t tempOut;
-	tempOut  = ((int64_t)inArg0 * (0 - inFract));
+	tempOut  = ((int64_t)inArg0 * (((int64_t)1<<32) - inFract));
 	tempOut	+= ((int64_t)inArg1 * inFract);
 	tempOut >>= 32;
 	return (fix16_t)tempOut;

--- a/libfixmath/int64.h
+++ b/libfixmath/int64.h
@@ -19,7 +19,7 @@ static inline int64_t int64_neg(int64_t x)              { return (-x);     }
 static inline int64_t int64_sub(int64_t x, int64_t y)   { return (x - y);  }
 static inline int64_t int64_shift(int64_t x, int8_t y)  { return (y < 0 ? (x >> -y) : (x << y)); }
 
-static inline int64_t int64_mul_i32_i32(int32_t x, int32_t y) { return (x * y);  }
+static inline int64_t int64_mul_i32_i32(int32_t x, int32_t y) { return ((int64_t)x * y);  }
 static inline int64_t int64_mul_i64_i32(int64_t x, int32_t y) { return (x * y);  }
 
 static inline int64_t int64_div_i64_i32(int64_t x, int32_t y) { return (x / y);  }

--- a/unittests/fix16_unittests.c
+++ b/unittests/fix16_unittests.c
@@ -330,6 +330,36 @@ int main()
     TEST(failures == 0);
   }
   
+#ifndef FIXMATH_NO_64BIT
+  {
+    COMMENT("Running linear interpolation test cases");
+    
+    TEST(fix16_lerp8(0, 2, 0) == 0);
+    TEST(fix16_lerp8(0, 2, 127) == 0);
+    TEST(fix16_lerp8(0, 2, 128) == 1);
+    TEST(fix16_lerp8(0, 2, 255) == 1);
+    TEST(fix16_lerp8(fix16_minimum, fix16_maximum, 0) == fix16_minimum);
+    TEST(fix16_lerp8(fix16_minimum, fix16_maximum, 255) == (fix16_maximum - (1<<24)));
+    TEST(fix16_lerp8(-fix16_maximum, fix16_maximum, 128) == 0);
+    
+    TEST(fix16_lerp16(0, 2, 0) == 0);
+    TEST(fix16_lerp16(0, 2, 0x7fff) == 0);
+    TEST(fix16_lerp16(0, 2, 0x8000) == 1);
+    TEST(fix16_lerp16(0, 2, 0xffff) == 1);
+    TEST(fix16_lerp16(fix16_minimum, fix16_maximum, 0) == fix16_minimum);
+    TEST(fix16_lerp16(fix16_minimum, fix16_maximum, 0xffff) == (fix16_maximum - (1<<16)));
+    TEST(fix16_lerp16(-fix16_maximum, fix16_maximum, 0x8000) == 0);
+    
+    TEST(fix16_lerp32(0, 2, 0) == 0);
+    TEST(fix16_lerp32(0, 2, 0x7fffffff) == 0);
+    TEST(fix16_lerp32(0, 2, 0x80000000) == 1);
+    TEST(fix16_lerp32(0, 2, 0xffffffff) == 1);
+    TEST(fix16_lerp32(fix16_minimum, fix16_maximum, 0) == fix16_minimum);
+    TEST(fix16_lerp32(fix16_minimum, fix16_maximum, 0xffffffff) == (fix16_maximum - 1));
+    TEST(fix16_lerp32(-fix16_maximum, fix16_maximum, 0x80000000) == 0);
+  }
+#endif
+  
   if (status != 0)
     fprintf(stdout, "\n\nSome tests FAILED!\n");
   


### PR DESCRIPTION
I added a few unit tests for the "lerp" functions ahead of modifying them for issue #19, and it turned out there were a couple of existing type conversion bugs. It was failing all test cases for lerp8, and ones with non-zero inArg0 for lerp32.