### PR TITLE
Add LICENSE

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+Chris Hammond <chammond@prattmiller.com>
+David Lechner <david@pybricks.com>
+Flatmush <Flatmush@gmail.com>
+Gaëtan Harter <gaetan.harter@fu-berlin.de>
+Joe Schaack <joe.schaack@gmail.com>
+Martin Larralde <martin.larralde@ens-paris-saclay.fr>
+Petteri Aimonen <Petteri.Aimonen@gmail.com, jpa@github.mail.kapsi.fi>
+Stargirl Flowers <me@thea.codes>
+Vincent del Medico <vincent.del.medico@gmail.com>
+Vitaly Puzrin <vitaly@rcdesign.ru>
+Xin Li <sam@babeltimeus.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-libfixmath is Copyright (c) 2011-2021 Petteri Aimonen
+libfixmath is Copyright (c) 2011-2021 Flatmush <Flatmush@gmail.com>,
+Petteri Aimonen <Petteri.Aimonen@gmail.com>, & libfixmath AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+libfixmath is Copyright (c) 2011-2021 Petteri Aimonen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This library is wonderful, however, it's missing an explicit license in its source code. This adds the text of the MIT license along with the name of the original author. This helps folks like me make sure we follow the license terms when using this library. :)