### PR TITLE
signed integer overflow is undefined behavior

### DIFF
--- a/libfixmath/fix16.h
+++ b/libfixmath/fix16.h
@@ -87,7 +87,7 @@ static inline fix16_t fix16_from_dbl(double a)
 #define F16(x) ((fix16_t)(((x) >= 0) ? ((x) * 65536.0 + 0.5) : ((x) * 65536.0 - 0.5)))
 
 static inline fix16_t fix16_abs(fix16_t x)
-	{ return (x < 0 ? -x : x); }
+    { return (x < 0 ? -(uint32_t)x : x); }
 static inline fix16_t fix16_floor(fix16_t x)
 	{ return (x & 0xFFFF0000UL); }
 static inline fix16_t fix16_ceil(fix16_t x)


### PR DESCRIPTION
as stated here: https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Integer-Overflow-Basics.html and here: https://stackoverflow.com/questions/18195715/why-is-unsigned-integer-overflow-defined-behavior-but-signed-integer-overflow-is .
This causes problems with `fix16_abs` on higher optimization levels (-O2). This fix will work, because it will overflow the right way for processors, that use two's complement for signed numbers, see: https://stackoverflow.com/questions/8026694/c-unary-minus-operator-behavior-with-unsigned-operands