### PR TITLE
fix warnings related to signed char used in macros on some platforms

### DIFF
--- a/libfixmath/fix16_fft.c
+++ b/libfixmath/fix16_fft.c
@@ -128,7 +128,7 @@ void fix16_fft(INPUT_TYPE *input, fix16_t *real, fix16_t *imag, unsigned transfo
         four_point_dft(input + INPUT_INDEX(rbit_n(i, log_length - 2)), transform_length / 4, real + 4*i, imag + 4*i);
     }
 
-    for (i = 2; i < log_length; i++)
+    for (i = 2; i < (unsigned) log_length; i++)
     {
         butterfly(real, imag, 1 << i, transform_length / (2 << i));
     }

--- a/libfixmath/fix16_str.c
+++ b/libfixmath/fix16_str.c
@@ -71,7 +71,7 @@ void fix16_to_str(fix16_t value, char *buf, int decimals)
 
 fix16_t fix16_from_str(const char *buf)
 {
-    while (isspace(*buf))
+    while (isspace((unsigned char) *buf))
         buf++;
     
     /* Decode the sign */
@@ -82,7 +82,7 @@ fix16_t fix16_from_str(const char *buf)
     /* Decode the integer part */
     uint32_t intpart = 0;
     int count = 0;
-    while (isdigit(*buf))
+    while (isdigit((unsigned char) *buf))
     {
         intpart *= 10;
         intpart += *buf++ - '0';
@@ -102,7 +102,7 @@ fix16_t fix16_from_str(const char *buf)
         
         uint32_t fracpart = 0;
         uint32_t scale = 1;
-        while (isdigit(*buf) && scale < 100000)
+        while (isdigit((unsigned char) *buf) && scale < 100000)
         {
             scale *= 10;
             fracpart *= 10;
@@ -115,7 +115,7 @@ fix16_t fix16_from_str(const char *buf)
     /* Verify that there is no garbage left over */
     while (*buf != '\0')
     {
-        if (!isdigit(*buf) && !isspace(*buf))
+        if (!isdigit((unsigned char) *buf) && !isspace((unsigned char) *buf))
             return fix16_overflow;
         
         buf++;


### PR DESCRIPTION
Specifically on windows, `char` is signed, so it produces a warning in the `isdigit` and `isspace` macros in `fix16_str.c`.
More context: https://stackoverflow.com/a/10186479/1976323

Also fixed a signed/unsigned int comparison in `fix16_fft`.