### PR TITLE
Support to work for linux kernel modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project(libfixmath LANGUAGES CXX C)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_C_FLAGS "-Wall -pedantic -Wextra -Werror=return-type")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -Werror=return-type")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-Wall -pedantic -Wextra -Werror=return-type")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Werror=return-type")
 
 include(libfixmath/libfixmath.cmake)
 include(tests/tests.cmake)

--- a/libfixmath/fix16.h
+++ b/libfixmath/fix16.h
@@ -21,7 +21,11 @@ extern "C"
 # endif
 #endif
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
 #include <stdint.h>
+#endif
 
 typedef int32_t fix16_t;
 

--- a/libfixmath/fix16_exp.c
+++ b/libfixmath/fix16_exp.c
@@ -1,5 +1,11 @@
 #include "fix16.h"
+#ifdef __KERNEL__
+#include <linux/types.h>
+#define uint_fast8_t uint8_t
+#else
 #include <stdbool.h>
+#endif
+
 
 #ifndef FIXMATH_NO_CACHE
 static fix16_t _fix16_exp_cache_index[4096]  = { 0 };

--- a/libfixmath/fix16_fft.c
+++ b/libfixmath/fix16_fft.c
@@ -8,7 +8,11 @@
  * This file is released to public domain.
  */
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
 #include <stdint.h>
+#endif
 #include "fix16.h"
 
 // You can change the input datatype and intermediate scaling here.

--- a/libfixmath/fix16_str.c
+++ b/libfixmath/fix16_str.c
@@ -1,8 +1,10 @@
 #include "fix16.h"
-#include <stdbool.h>
-#ifndef FIXMATH_NO_CTYPE
-#include <ctype.h>
+#ifdef __KERNEL__
+#include <linux/types.h>
 #else
+#include <stdbool.h>
+#endif
+#if defined(FIXMATH_NO_CTYPE) || defined(__KERNEL__)
 static inline int isdigit(int c)
 {
     return c >= '0' && c <= '9';
@@ -12,6 +14,8 @@ static inline int isspace(int c)
 {
     return c == ' ' || c == '\r' || c == '\n' || c == '\t' || c == '\v' || c == '\f';
 }
+#else
+#include <ctype.h>
 #endif
 
 static const uint32_t scales[8] = {

--- a/libfixmath/fix16_trig.c
+++ b/libfixmath/fix16_trig.c
@@ -1,4 +1,10 @@
+#ifdef __KERNEL__
+#ifndef CHAR_BIT
+#define CHAR_BIT 8	/* Normally in <limits.h> */
+#endif
+#else
 #include <limits.h>
+#endif
 #include "fix16.h"
 
 #if defined(FIXMATH_SIN_LUT)

--- a/libfixmath/fract32.h
+++ b/libfixmath/fract32.h
@@ -6,7 +6,11 @@ extern "C"
 {
 #endif
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
 #include <stdint.h>
+#endif
 
 typedef uint32_t fract32_t;
 

--- a/libfixmath/int64.h
+++ b/libfixmath/int64.h
@@ -6,7 +6,11 @@ extern "C"
 {
 #endif
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
 #include <stdint.h>
+#endif
 
 #ifndef FIXMATH_NO_64BIT
 static inline  int64_t int64_const(int32_t hi, uint32_t lo) { return (((int64_t)hi << 32) | lo); }

--- a/libfixmath/uint32.h
+++ b/libfixmath/uint32.h
@@ -6,7 +6,11 @@ extern "C"
 {
 #endif
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#else
 #include <stdint.h>
+#endif
 
 /*! Performs an unsigned log-base2 on the specified unsigned integer and returns the result.
 */


### PR DESCRIPTION
This PR uses linux/types.h instead of stdint.h, stdbool.h or any other related external libc dependencies in the headers and c-files, when compiled for usage in a kernel module (Some #ifdef __KERNEL__ switches basically)

Further more, the CMakeList.txt has been modified, to allow to supply CMAKE_C_FLAGS and CMAKE_CXX_FLAGS via CLI. This is helpful, when libfixmath is compiled as a library by cmake via CLI, which then is used to be linked against e.g. a kernel module or anything else, that needs e.g. preprocessor flags like FIXMATH_NO_CTYPE set.

