### PR TITLE
Manage includes with target_include_directories

### DIFF
--- a/libfixmath/libfixmath.cmake
+++ b/libfixmath/libfixmath.cmake
@@ -1,3 +1,6 @@
-file(GLOB libfixmath-srcs libfixmath/*.h libfixmath/*.hpp libfixmath/*.c)
+file(GLOB libfixmath-srcs libfixmath/*.c)
 
 add_library(libfixmath STATIC ${libfixmath-srcs})
+
+target_include_directories(libfixmath INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -22,6 +22,8 @@ add_custom_target(make_tests)
 
 function(create_variant name defs)
     add_library(libfixmath_${name} STATIC ${libfixmath-srcs})
+    target_include_directories(libfixmath_${name} INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(libfixmath_${name} PRIVATE ${defs})
     target_compile_options(libfixmath_${name} PRIVATE ${sanitizer_opts})
     target_link_options(libfixmath_${name} PRIVATE ${sanitizer_opts})


### PR DESCRIPTION
In order to use libfix math with cmake dependency manager, included
directories are handled with target_include_directories().

This allows a parent cmake project using libfixmath to pull includes
with target_link_libraries(), thus easing dependency management with
cmake modules such as FetchContent.