### PR TITLE
Update cmake_minimum_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 
 project(libfixmath LANGUAGES CXX C)
 


### PR DESCRIPTION
target_link_options has been added in 3.13, raise
cmake_minimum_version accordingly.