### PR TITLE
fix AVR build

### DIFF
--- a/libfixmath/uint32.c
+++ b/libfixmath/uint32.c
@@ -6,7 +6,7 @@ uint32_t uint32_log2(uint32_t inVal) {
 	if(inVal == 0)
 		return 0;
 	uint32_t tempOut = 0;
-	if(inVal >= (1 << 16)) { inVal >>= 16; tempOut += 16; }
+	if(inVal >= (1UL << 16)) { inVal >>= 16; tempOut += 16; }
 	if(inVal >= (1 <<  8)) { inVal >>=  8; tempOut +=  8; }
 	if(inVal >= (1 <<  4)) { inVal >>=  4; tempOut +=  4; }
 	if(inVal >= (1 <<  2)) { inVal >>=  2; tempOut +=  2; }

--- a/tests/tests_lerp.c
+++ b/tests/tests_lerp.c
@@ -18,7 +18,7 @@ int test_lerp()
     ASSERT_EQ_INT(fix16_lerp16(0, 2, 0xffff), 1);
     ASSERT_EQ_INT(fix16_lerp16(fix16_minimum, fix16_maximum, 0), fix16_minimum);
     ASSERT_EQ_INT(fix16_lerp16(fix16_minimum, fix16_maximum, 0xffff),
-                  (fix16_maximum - (1 << 16)));
+                  (fix16_maximum - (1UL << 16)));
     ASSERT_EQ_INT(fix16_lerp16(-fix16_maximum, fix16_maximum, 0x8000), 0);
 
     ASSERT_EQ_INT(fix16_lerp32(0, 2, 0), 0);


### PR DESCRIPTION
This fixes an otherwise signed left shift being beyond the bounds on 16 bit `int`.

```
/home/benpicco/dev/RIOT/build/pkg/libfixmath/libfixmath/uint32.c:9:17: error: left shift count >= width of type [-Werror=shift-count-overflow]
  if(inVal >= (1 << 16)) { inVal >>= 16; tempOut += 16; }
                 ^
/home/benpicco/dev/RIOT/build/pkg/libfixmath/libfixmath/uint32.c:9:11: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]
  if(inVal >= (1 << 16)) { inVal >>= 16; tempOut += 16; }
           ^
```