### PR TITLE
Add FIXMATH_NO_OVERFLOW condition to fix16_str.c

### DIFF
--- a/libfixmath/fix16_str.c
+++ b/libfixmath/fix16_str.c
@@ -93,9 +93,14 @@ fix16_t fix16_from_str(const char *buf)
         count++;
     }
     
+    #ifdef FIXMATH_NO_OVERFLOW
+    if (count == 0)
+        return fix16_overflow;
+    #else
     if (count == 0 || count > 5
         || intpart > 32768 || (!negative && intpart > 32767))
         return fix16_overflow;
+    #endif
     
     fix16_t value = intpart << 16;
     


### PR DESCRIPTION
Currently, `fix16_str()` will return `fix16_overflow` if the number it is parsing overflows. However, this behavior is inconsistent with the `FIXMATH_NO_OVERFLOW` setting, which is supposed to ignore all anti-overflow behavior. This PR fixes this issue by adding a condition for this setting to skip over the anti-overflow code (but still have a check for empty strings).

With this patch, there are still two cases where `fix16_str()` will return `fix16_overflow` with `FIXMATH_NO_OVERFLOW`: if the input string is empty, and if there are any "garbage characters" in the string. However, I didn't see any viable alternatives, so I didn't touch it. However, these mistakenly assume `fix16_overflow` will be used as error detection, when it is also a valid value. Perhaps a new parameter that returns the function's success as a bool should be added?