### PR TITLE
Feature/cmake fetch content compat

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Stargirl Flowers <me@thea.codes>
 Vincent del Medico <vincent.del.medico@gmail.com>
 Vitaly Puzrin <vitaly@rcdesign.ru>
 Xin Li <sam@babeltimeus.com>
+J.P. Hutchins <jp@intercreate.io>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,17 +11,19 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Werror=return-type")
 
 include(libfixmath/libfixmath.cmake)
-include(tests/tests.cmake)
 
-file(GLOB fixsingen-srcs fixsingen/*.c)
-file(GLOB fixtest-srcs fixtest/*.c fixtest/*.h)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # We're in the root, define additional targets for developers.
+    include(tests/tests.cmake)
 
-add_executable(fixtest ${fixtest-srcs})
-target_link_libraries(fixtest PRIVATE libfixmath m)
-target_include_directories(fixtest PRIVATE ${CMAKE_SOURCE_DIR})
+    file(GLOB fixsingen-srcs fixsingen/*.c)
+    file(GLOB fixtest-srcs fixtest/*.c fixtest/*.h)
 
-add_executable(fixsingen ${fixsingen-srcs})
-target_link_libraries(fixsingen PRIVATE libfixmath m)
-target_include_directories(fixsingen PRIVATE ${CMAKE_SOURCE_DIR})
+    add_executable(fixtest ${fixtest-srcs})
+    target_link_libraries(fixtest PRIVATE libfixmath m)
+    target_include_directories(fixtest PRIVATE ${CMAKE_SOURCE_DIR})
 
-
+    add_executable(fixsingen ${fixsingen-srcs})
+    target_link_libraries(fixsingen PRIVATE libfixmath m)
+    target_include_directories(fixsingen PRIVATE ${CMAKE_SOURCE_DIR})
+endif()

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The simplest way to use `libfixmath` as a dependency is with CMake's [FetchConte
 include(FetchContent)
 FetchContent_Declare(
     libfixmath
-    GIT_REPOSITORY https://github.com/intercreate/libfixmath.git
+    GIT_REPOSITORY https://github.com/PetteriAimonen/libfixmath.git
     GIT_TAG <the long git hash of the version you want>
 )
 FetchContent_MakeAvailable(libfixmath)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,62 @@ This is a mirror of the libfixmath's original SVN repository on Google Code.
 Libfixmath implements Q16.16 format fixed point operations in C.
 
 License: <a href="http://www.opensource.org/licenses/mit-license.php">MIT</a>
+
+# Options
+
+Configuration options are compile definitions that are checked by the preprocessor with `#ifdef` and `#ifndef`.  All of these are undefined by default.
+
+#### `FIXMATH_FAST_SIN`
+
+- `#ifndef`: Most accurate version, accurate to ~2.1%.
+- `#ifdef`: Fast implementation, runs at 159% the speed of above 'accurate' version with a slightly lower accuracy of ~2.3%.
+
+#### `FIXMATH_NO_64BIT`
+
+- `#ifndef`: For compilers/platforms that have `uint64_t`.
+- `#ifdef`: For compilers/platforms that do not have `uint64_t`.
+
+#### `FIXMATH_NO_CACHE`
+
+- `#ifndef`: Use static memory caches for exponents (32KB) and trigonometry (80KB). 
+- `#ifdef`: Do not use caches.
+
+#### `FIXMATH_NO_OVERFLOW`
+
+- `#ifndef`: Check for overflow and return the overflow constants. 
+- `#ifdef`: Do not check for overflow.
+
+#### `FIXMATH_NO_ROUNDING`
+
+- `#ifndef`: Use rounding. 
+- `#ifdef`: Do not use rounding.
+
+#### `FIXMATH_OPTIMIZE_8BIT`
+
+- `#ifndef`: Do not optimize for processors with 8-bit multiplication like Atmel AVR. 
+- `#ifdef`: Optimize for processors like Atmel AVR.  Compiles `fix16_div` for platforms that do not have hardware division.
+
+# Include the `libfixmath` library in your CMake Project
+
+The simplest way to use `libfixmath` as a dependency is with CMake's [FetchContent API](https://cmake.org/cmake/help/latest/module/FetchContent.html).
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(
+    libfixmath
+    GIT_REPOSITORY https://github.com/intercreate/libfixmath.git
+    GIT_TAG <the long git hash of the version you want>
+)
+FetchContent_MakeAvailable(libfixmath)
+
+target_compile_definitions(libfixmath PRIVATE
+    # FIXMATH_FAST_SIN
+    # FIXMATH_NO_64BIT
+    # FIXMATH_NO_CACHE
+    # FIXMATH_NO_OVERFLOW
+    # FIXMATH_NO_ROUNDING
+    # FIXMATH_OPTIMIZE_8BIT
+)
+
+target_link_libraries(my_cmake_project PRIVATE libfixmath)
+```


### PR DESCRIPTION
Hello!  Thank you for maintaining this library on GitHub!

This PR modifies the root CMakeLists to be easily compatible with CMake's FetchContent API, a strategy that is inspired by this excellent write-up: https://www.foonathan.net/2022/06/cmake-fetchcontent/

I have confirmed the FetchContent functionality in the project from which I intend to use libfixmath as a dependency and documented the process in this README.

Also in the README is an explanation of the compile options.

Cheers,
J.P.