### PR TITLE
Avoid overflow in fix16_to_int rounding

### DIFF
--- a/libfixmath/fix16.h
+++ b/libfixmath/fix16.h
@@ -63,9 +63,13 @@ static inline int fix16_to_int(fix16_t a)
 #ifdef FIXMATH_NO_ROUNDING
     return (a >> 16);
 #else
-	if (a >= 0)
-		return (a + (fix16_one >> 1)) / fix16_one;
-	return (a - (fix16_one >> 1)) / fix16_one;
+	int result = a / fix16_one;
+	fix16_t remainder = a % fix16_one;
+	if (remainder >= (fix16_one >> 1))
+		return result + 1;
+	if (remainder <= -(fix16_one >> 1))
+		return result - 1;
+	return result;
 #endif
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -70,6 +70,7 @@ int main()
     }
 
 #else
+    TEST(test_to_int());
     TEST(test_abs());
     TEST(test_add());
     TEST(test_mul());

--- a/tests/tests_basic.c
+++ b/tests/tests_basic.c
@@ -1,6 +1,19 @@
 #include "tests_basic.h"
 #include "tests.h"
 
+int test_to_int(void)
+{
+#ifndef FIXMATH_NO_ROUNDING
+    ASSERT_EQ_INT(fix16_to_int(fix16_minimum), -32768);
+    ASSERT_EQ_INT(fix16_to_int(fix16_maximum), 32768);
+    ASSERT_EQ_INT(fix16_to_int(0x00007FFF), 0);
+    ASSERT_EQ_INT(fix16_to_int(0x00008000), 1);
+    ASSERT_EQ_INT(fix16_to_int(-0x00007FFF), 0);
+    ASSERT_EQ_INT(fix16_to_int(-0x00008000), -1);
+#endif
+    return 0;
+}
+
 int test_abs_short(void)
 {
     for (unsigned i = 0; i < TESTCASES_COUNT; ++i)

--- a/tests/tests_basic.h
+++ b/tests/tests_basic.h
@@ -2,6 +2,7 @@
 #define TESTS_BASIC_H
 
 int test_abs(void);
+int test_to_int(void);
 int test_add(void);
 int test_mul(void);
 int test_div(void);


### PR DESCRIPTION
## Summary

- avoid signed overflow when rounding the Q16.16 endpoints
- preserve half-away-from-zero behavior without a 64-bit intermediate
- add endpoint and half-value conversion regressions

## Reproduction

With the previous implementation, converting fix16_minimum under UBSan reports signed integer overflow and returns 32767 instead of -32768. fix16_maximum similarly returns -32767 instead of 32768.

The updated implementation rounds from the quotient and remainder, so it remains compatible with FIXMATH_NO_64BIT.

## Testing

- all 24 CTest variants pass, including UBSan, FIXMATH_NO_64BIT, FIXMATH_OPTIMIZE_8BIT, and FIXMATH_NO_ROUNDING combinations
- changed tests compile with GCC -std=c11 -Wall -Wextra -Werror -pedantic